### PR TITLE
Drop pip ecosystem from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

No `requirements.txt`, `pyproject.toml`, or `Dockerfile` lives in this repo, so Dependabot has been failing daily with `dependency_file_not_found: "No files found in /"`. Keep `github-actions` only.

## Test plan

- [ ] No new `Dependabot Updates` failures appear after merge.